### PR TITLE
Update getData.js for deprecations

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,1 @@
-registry="https://registry.npm.taobao.org/"
+registry="https://registry.npmmirror.com/"

--- a/src/api/getData.js
+++ b/src/api/getData.js
@@ -188,7 +188,7 @@ export const createTranslation = (formData, token) => {
 export const createFineTune = (formData, token) => {
   return axios({
     method: 'post',
-    baseURL: `${baseUrl}/v1/fine-tunes`,
+    baseURL: `${baseUrl}/v1/fine_tuning/jobs/`,
     headers: {
       'Authorization': 'Bearer ' + token,
       'Content-Type':  'application/json'
@@ -206,7 +206,7 @@ export const createFineTune = (formData, token) => {
 export const getFineTunesList = token => {
   return axios({
     method: 'get',
-    baseURL: `${baseUrl}/v1/fine-tunes`,
+    baseURL: `${baseUrl}/v1/fine_tuning/jobs/`,
     headers: {
       'Authorization': 'Bearer ' + token,
       'Content-Type': 'application/json'
@@ -238,7 +238,7 @@ export const getFineTunesList = token => {
 export const retrieveFineTune = (fineTuneId, token) => {
   return axios({
     method: 'get',
-    baseURL: `${baseUrl}/v1/fine-tunes/` + fineTuneId,
+    baseURL: `${baseUrl}/v1/fine_tuning/jobs/` + fineTuneId,
     headers: {
       'Authorization': 'Bearer ' + token,
       'Content-Type': 'application/json'
@@ -254,7 +254,7 @@ export const retrieveFineTune = (fineTuneId, token) => {
 export const cancelFineTune = (fineTuneId, token) => {
   return axios({
     method: 'post',
-    baseURL: `${baseUrl}/v1/fine-tunes/` + fineTuneId + '/cancel',
+    baseURL: `${baseUrl}/v1/fine_tuning/jobs/` + fineTuneId + '/cancel',
     headers: {
       'Authorization': 'Bearer ' + token,
       'Content-Type': 'application/json'
@@ -268,7 +268,7 @@ export const cancelFineTune = (fineTuneId, token) => {
 export const getFineTuneEventsList = (fineTuneId, token) => {
   return axios({
     method: 'get',
-    baseURL: `${baseUrl}/v1/fine-tunes/` + fineTuneId + '/events',
+    baseURL: `${baseUrl}/v1/fine_tuning/jobs/` + fineTuneId + '/events',
     headers: {
       'Authorization': 'Bearer ' + token,
       'Content-Type': 'multipart/form-data'


### PR DESCRIPTION
2023-08-22: Fine-tunes endpoint
On August 22nd, 2023, we announced the new fine-tuning API (/v1/fine_tuning/jobs) and that the original /v1/fine-tunes API along with legacy models (including those fine-tuned with the /v1/fine-tunes API) will be shut down on January 04, 2024. This means that models fine-tuned using the /v1/fine-tunes API will no longer be accessible and you would have to fine-tune new models with the updated endpoint and associated base models.

https://platform.openai.com/docs/deprecations/2023-08-22-fine-tunes-endpoint